### PR TITLE
Rails 3.0 generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ With pure javascript, the lines would look like `app/assets/javascripts/applicat
     //= require underscore
     //= require backbone
 
+### Rails 3.0 generator
+
+In Rails 3.0, you can also vendor Backbone into your public/javascripts directory with `rails g backbone:install`
+
 ## Versioning
 
 The gem will follow backbone versioning.

--- a/backbone-rails.gemspec
+++ b/backbone-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
  
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "railties", "~> 3.1.0.beta1"
+  s.add_dependency "rails", ">= 3.0.0"
 
   s.files        = Dir.glob("{lib,vendor}/**/*") + %w(MIT-LICENSE README.md)
   s.require_path = 'lib'

--- a/lib/backbone-rails.rb
+++ b/lib/backbone-rails.rb
@@ -1,9 +1,11 @@
+require 'rails'
 
 module Backbone
   module Rails
-
-    class Engine < ::Rails::Engine
+    if ::Rails.version < "3.1"
+      require 'backbone-rails/railtie'
+    else
+      require 'backbone-rails/engine'
     end
-
   end
 end

--- a/lib/backbone-rails/engine.rb
+++ b/lib/backbone-rails/engine.rb
@@ -1,0 +1,9 @@
+require 'rails'
+
+module Backbone
+  module Rails
+    class Engine < ::Rails::Engine
+    end
+  end
+end
+

--- a/lib/backbone-rails/generators.rb
+++ b/lib/backbone-rails/generators.rb
@@ -1,0 +1,19 @@
+require 'rails/generators'
+
+module Backbone
+  class Install < ::Rails::Generators::Base
+    JAVASCRIPTS = File.expand_path('../../../vendor/assets/javascripts', __FILE__)
+
+    def self.source_root
+      @source_root ||= JAVASCRIPTS
+    end
+
+    def copy_backbone
+      Dir[File.join(JAVASCRIPTS, '*.js')].each do |file|
+        file = File.split(file).last
+        copy_file file, "public/javascripts/#{file}"
+      end
+    end
+  end
+end
+

--- a/lib/backbone-rails/railtie.rb
+++ b/lib/backbone-rails/railtie.rb
@@ -1,0 +1,12 @@
+require 'rails'
+
+module Backbone
+  module Rails
+    class Railtie < ::Rails::Railtie
+      generators do
+        require 'backbone-rails/generators'
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
`rails g backbone:install` puts the included version in the junk drawer of `public/javascripts`.
